### PR TITLE
closes #16 backend now handles rename and returns descriptive error

### DIFF
--- a/app/data_structures/crud.py
+++ b/app/data_structures/crud.py
@@ -96,16 +96,23 @@ def get_segment_geoms_by_user_study(db: Session, username: str, study: str, mode
 
 def rename_segment(db: Session, oldName: str, newName: str, username: str):
     newName = re.sub(r"[^a-zA-Z0-9 ]", "", newName)
-    stmt = (
-        update(models.UserSegments)
-        .where(
-            (models.UserSegments.username == username)
-            & (models.UserSegments.seg_name == oldName)
-        )
-        .values(seg_name=newName)
+    exists = (
+        db.query(models.UserSegments.seg_name).filter_by(seg_name=newName).first()
+        is not None
     )
-    db.execute(stmt)
-    db.commit()
+    if not exists:
+        stmt = (
+            update(models.UserSegments)
+            .where(
+                (models.UserSegments.username == username)
+                & (models.UserSegments.seg_name == oldName)
+            )
+            .values(seg_name=newName)
+        )
+        db.execute(stmt)
+        db.commit()
+    else:
+        raise ValueError("Segment name was already used, try a different name.")
 
 
 def share_study(db: Session, username: str, seg_name: str, share: bool):

--- a/app/routers/rename.py
+++ b/app/routers/rename.py
@@ -2,7 +2,7 @@ import os
 from typing_extensions import Annotated
 
 from dotenv import load_dotenv
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, HTTPException
 from sqlalchemy.orm import Session
 
 from data_structures import crud, database, schemas
@@ -22,6 +22,9 @@ def analyze_segment(
     schema: str = Query(..., description="The schema to use (lts or sidewalk)"),
     db: Session = Depends(database.get_db_for_schema),
 ):
-    db_studies = crud.rename_segment(db, data.oldName, data.newName, username)
+    try:
+        db_studies = crud.rename_segment(db, data.oldName, data.newName, username)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
 
     return {"message": f"Data received: {db_studies}"}


### PR DESCRIPTION
still need to use the error on front end, but duplicate renames are no longer possible