### PR TITLE
Id and name field fixes

### DIFF
--- a/app/data_structures/schemas.py
+++ b/app/data_structures/schemas.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import List, Any, Optional, Literal
+from typing import List, Any, Optional, Union, Literal
 from enum import Enum
 
 
@@ -20,10 +20,10 @@ class Geometry(BaseModel):
 
 
 class FeatureModel(BaseModel):
-    type: str = 'Feature'
+    type: str = "Feature"
     geometry: Optional[Geometry] = None
     properties: Optional[dict] = None
-    id: Optional[str] = None
+    id: Optional[Union[str, int]] = None
 
 
 class GeoJson(BaseModel):
@@ -66,8 +66,8 @@ class UserStudies(BaseModel):
 
 
 class RenameRequest(BaseModel):
-    oldName: str = Field(..., alias='oldName')
-    newName: str = Field(..., alias='newName')
+    oldName: str = Field(..., alias="oldName")
+    newName: str = Field(..., alias="newName")
 
 
 class Geom(BaseModel):
@@ -91,6 +91,7 @@ class FeatureCollection(BaseModel):
 
 class AnalyzeRequest(BaseModel):
     """For any requests coming in from the analyze button."""
+
     connection_type: str
     geo_json: FeatureCollection
     username: str

--- a/requirements_base.txt
+++ b/requirements_base.txt
@@ -1,6 +1,6 @@
 fastapi==0.103.1
 httptools==0.6.0
-lts-island-connectivity @ git+https://github.com/dvrpc/LTS_island_connectivity@0.1.1#egg=lts-island-connectivity
+lts-island-connectivity @ git+https://github.com/dvrpc/LTS_island_connectivity@0.2.2#egg=lts-island-connectivity
 pyyaml==6.0.1
 uvicorn==0.23.2
 uvloop==0.17.0


### PR DESCRIPTION
allow id column (which isn't really used and is optional) to be string or int, also bump lts version to allow for handling of 'name' and 'Name' columns. both spurred by consultant using link on project in delco and using geojsons generated from esri